### PR TITLE
동호회 조회, 수정, 삭제 API

### DIFF
--- a/src/main/java/porori/backend/domain/application/model/dto/ApplicationCreateResponseDTO.java
+++ b/src/main/java/porori/backend/domain/application/model/dto/ApplicationCreateResponseDTO.java
@@ -1,17 +1,24 @@
 package porori.backend.domain.application.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import porori.backend.domain.application.model.entity.Application;
 import porori.backend.domain.application.model.entity.ApplicationStatus;
 
+@Schema(description = "동호회 가입 신청 Response : 동호회 가입 신청 후 얻을 수 있는 정보")
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
 public class ApplicationCreateResponseDTO {
 
+    @Schema(description = "유저 ID", example = "1")
     private Long userId;
+
+    @Schema(description = "동호회 ID", example = "1")
     private Long clubId;
+
+    @Schema(description = "지원 상태", example = "APPLIED")
     private ApplicationStatus applicationStatus;
 
     public static ApplicationCreateResponseDTO from(Application application) {

--- a/src/main/java/porori/backend/domain/club/api/ClubController.java
+++ b/src/main/java/porori/backend/domain/club/api/ClubController.java
@@ -21,11 +21,17 @@ public class ClubController {
 
     private final ClubService clubService;
 
-    @PostMapping(value = "/create")
+    @PostMapping("/create")
     @Operation(summary = "동호회 생성", description = "유저가 동호회를 생성한다.")
     public SuccessResponse<ClubCreateResponseDTO> createClub(@RequestHeader("Authorization") String token,
                                                             @RequestBody ClubCreateRequestDTO clubCreateRequestDTO) {
         return new SuccessResponse<>(CREATE_CLUB, clubService.createClub(token, clubCreateRequestDTO));
+    }
+
+    @GetMapping("/subjects")
+    @Operation(summary = "동호회 주제 조회", description = "동호회 생성을 위해 동호회의 주제를 조회한다.")
+    public SuccessResponse<List<ClubSubjectResponseDTO>> getClubSubjects() {
+        return new SuccessResponse<>(SUCCESS, clubService.getClubSubjects());
     }
 
     @GetMapping("/all")

--- a/src/main/java/porori/backend/domain/club/api/ClubController.java
+++ b/src/main/java/porori/backend/domain/club/api/ClubController.java
@@ -6,10 +6,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import porori.backend.domain.club.model.dto.ClubCreateRequestDTO;
 import porori.backend.domain.club.model.dto.ClubCreateResponseDTO;
+import porori.backend.domain.club.model.dto.ClubGetResponseDTO;
 import porori.backend.domain.club.service.ClubService;
 import porori.backend.global.common.dto.response.SuccessResponse;
 
+import java.util.List;
+
 import static porori.backend.global.common.status.SuccessStatus.CREATE_CLUB;
+import static porori.backend.global.common.status.SuccessStatus.SUCCESS;
 
 @Tag(name = "동호회 생성 및 수정 API")
 @RestController
@@ -26,5 +30,10 @@ public class ClubController {
         return new SuccessResponse<>(CREATE_CLUB, clubService.createClub(token, clubCreateRequestDTO));
     }
 
+    @GetMapping("/all")
+    @Operation(summary = "동호회 전체 조회", description = "동호회 전체를 조회한다.")
+    public SuccessResponse<List<ClubGetResponseDTO>> getAllClubs() {
+        return new SuccessResponse<>(SUCCESS, clubService.getAllClubs());
+    }
 
 }

--- a/src/main/java/porori/backend/domain/club/api/ClubController.java
+++ b/src/main/java/porori/backend/domain/club/api/ClubController.java
@@ -36,4 +36,10 @@ public class ClubController {
         return new SuccessResponse<>(SUCCESS, clubService.getAllClubs());
     }
 
+    @GetMapping("/subject/{subjectTitle}")
+    @Operation(summary = "동호회 주제에 따라 조회", description = "동호회 주제로 필터링하여 조회한다.")
+    public SuccessResponse<List<ClubGetResponseDTO>> getSubjectClubs(@PathVariable String subjectTitle) {
+        return new SuccessResponse<>(SUCCESS, clubService.getSubjectClubs(subjectTitle));
+    }
+
 }

--- a/src/main/java/porori/backend/domain/club/api/ClubController.java
+++ b/src/main/java/porori/backend/domain/club/api/ClubController.java
@@ -4,10 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import porori.backend.domain.club.model.dto.ClubCreateRequestDTO;
-import porori.backend.domain.club.model.dto.ClubCreateResponseDTO;
-import porori.backend.domain.club.model.dto.ClubGetResponseDTO;
-import porori.backend.domain.club.model.dto.ClubUpdateRequestDTO;
+import porori.backend.domain.club.model.dto.*;
 import porori.backend.domain.club.service.ClubService;
 import porori.backend.global.common.dto.response.SuccessResponse;
 
@@ -48,6 +45,13 @@ public class ClubController {
     public SuccessResponse<ClubGetResponseDTO> updateClub(@RequestHeader("Authorization") String token,
                                                              @RequestBody ClubUpdateRequestDTO clubUpdateRequestDTO) {
         return new SuccessResponse<>(SUCCESS, clubService.updateClub(token, clubUpdateRequestDTO));
+    }
+
+    @DeleteMapping("/delete")
+    @Operation(summary = "동호회 삭제", description = "자신이 관리자인 동호회를 삭제한다.")
+    public SuccessResponse<ClubDeleteResponseDTO> deleteClub(@RequestHeader("Authorization") String token,
+                                                             @RequestParam Long clubId) {
+        return new SuccessResponse<>(SUCCESS, clubService.deleteClub(token, clubId));
     }
 
 }

--- a/src/main/java/porori/backend/domain/club/api/ClubController.java
+++ b/src/main/java/porori/backend/domain/club/api/ClubController.java
@@ -40,6 +40,12 @@ public class ClubController {
         return new SuccessResponse<>(SUCCESS, clubService.getSubjectClubs(subjectTitle));
     }
 
+    @GetMapping("/detail")
+    @Operation(summary = "동호회 정보 조회", description = "동호회 ID로 동호회를 조회한다.")
+    public SuccessResponse<ClubGetResponseDTO> getClub(@RequestParam Long clubId) {
+        return new SuccessResponse<>(SUCCESS, clubService.getClub(clubId));
+    }
+
     @PatchMapping("/update")
     @Operation(summary = "동호회 수정", description = "자신이 관리자인 동호회를 수정한다.")
     public SuccessResponse<ClubGetResponseDTO> updateClub(@RequestHeader("Authorization") String token,

--- a/src/main/java/porori/backend/domain/club/api/ClubController.java
+++ b/src/main/java/porori/backend/domain/club/api/ClubController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*;
 import porori.backend.domain.club.model.dto.ClubCreateRequestDTO;
 import porori.backend.domain.club.model.dto.ClubCreateResponseDTO;
 import porori.backend.domain.club.model.dto.ClubGetResponseDTO;
+import porori.backend.domain.club.model.dto.ClubUpdateRequestDTO;
 import porori.backend.domain.club.service.ClubService;
 import porori.backend.global.common.dto.response.SuccessResponse;
 
@@ -40,6 +41,13 @@ public class ClubController {
     @Operation(summary = "동호회 주제에 따라 조회", description = "동호회 주제로 필터링하여 조회한다.")
     public SuccessResponse<List<ClubGetResponseDTO>> getSubjectClubs(@PathVariable String subjectTitle) {
         return new SuccessResponse<>(SUCCESS, clubService.getSubjectClubs(subjectTitle));
+    }
+
+    @PatchMapping("/update")
+    @Operation(summary = "동호회 수정", description = "자신이 관리자인 동호회를 수정한다.")
+    public SuccessResponse<ClubGetResponseDTO> updateClub(@RequestHeader("Authorization") String token,
+                                                             @RequestBody ClubUpdateRequestDTO clubUpdateRequestDTO) {
+        return new SuccessResponse<>(SUCCESS, clubService.updateClub(token, clubUpdateRequestDTO));
     }
 
 }

--- a/src/main/java/porori/backend/domain/club/model/dto/ClubCreateRequestDTO.java
+++ b/src/main/java/porori/backend/domain/club/model/dto/ClubCreateRequestDTO.java
@@ -1,17 +1,31 @@
 package porori.backend.domain.club.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Schema(description = "동호회 생성 Request : 동호회 생성 시 필요한 정보")
 @NoArgsConstructor
 @Getter
 public class ClubCreateRequestDTO {
+
+    @Schema(description = "동호회 이름", example = "산타는 할아버지")
     private String name;
+
+    @Schema(description = "동호회 주요 주제", example = "운동")
     private String subjectTitle;
+
+    @Schema(description = "동호회 세부 주제", example = "하이킹")
     private String subjectDetail;
+
+    @Schema(description = "동호회 주요 활동 위치", example = "거여동")
     private String location;
+
+    @Schema(description = "동호회 최대 수용 인원", example = "10")
     private int limitMemberNumber;
+
+    @Schema(description = "동호회 설명", example = "즐겁게 등산합시다")
     private String description;
 
     @Builder

--- a/src/main/java/porori/backend/domain/club/model/dto/ClubCreateRequestDTO.java
+++ b/src/main/java/porori/backend/domain/club/model/dto/ClubCreateRequestDTO.java
@@ -1,7 +1,6 @@
 package porori.backend.domain.club.model.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,13 +27,4 @@ public class ClubCreateRequestDTO {
     @Schema(description = "동호회 설명", example = "즐겁게 등산합시다")
     private String description;
 
-    @Builder
-    public ClubCreateRequestDTO(String name, String subjectTitle, String subjectDetail, String location, int limitMemberNumber, String description) {
-        this.name = name;
-        this.subjectTitle = subjectTitle;
-        this.subjectDetail = subjectDetail;
-        this.location = location;
-        this.limitMemberNumber = limitMemberNumber;
-        this.description = description;
-    }
 }

--- a/src/main/java/porori/backend/domain/club/model/dto/ClubCreateResponseDTO.java
+++ b/src/main/java/porori/backend/domain/club/model/dto/ClubCreateResponseDTO.java
@@ -1,13 +1,17 @@
 package porori.backend.domain.club.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import porori.backend.domain.club.model.entity.Club;
 
+@Schema(description = "동호회 생성 Response : 동호회 생성 후 얻을 수 있는 정보")
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
 public class ClubCreateResponseDTO {
+
+    @Schema(description = "동호회 ID", example = "1")
     private Long clubId;
 
     public static ClubCreateResponseDTO from(Club club) {

--- a/src/main/java/porori/backend/domain/club/model/dto/ClubDeleteResponseDTO.java
+++ b/src/main/java/porori/backend/domain/club/model/dto/ClubDeleteResponseDTO.java
@@ -1,0 +1,22 @@
+package porori.backend.domain.club.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import porori.backend.domain.club.model.entity.Club;
+
+@Schema(description = "동호회 삭제 Response : 동호회 삭제 후 얻을 수 있는 정보")
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ClubDeleteResponseDTO {
+
+    @Schema(description = "동호회 ID", example = "1")
+    private Long clubId;
+
+    public static ClubDeleteResponseDTO from(Club club) {
+        return ClubDeleteResponseDTO.builder()
+                .clubId(club.getClubId())
+                .build();
+    }
+}

--- a/src/main/java/porori/backend/domain/club/model/dto/ClubGetResponseDTO.java
+++ b/src/main/java/porori/backend/domain/club/model/dto/ClubGetResponseDTO.java
@@ -1,0 +1,51 @@
+package porori.backend.domain.club.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import porori.backend.domain.club.model.entity.Club;
+
+@Schema(description = "동호회 정보 조회 Response : 동호회 조회 시 얻을 수 있는 정보")
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ClubGetResponseDTO {
+
+    @Schema(description = "동호회 ID", example = "1")
+    private Long clubId;
+
+    @Schema(description = "동호회 이름", example = "산타는 할아버지")
+    private String name;
+
+    @Schema(description = "동호회 주요 주제", example = "운동")
+    private String subjectTitle;
+
+    @Schema(description = "동호회 세부 주제", example = "하이킹")
+    private String subjectDetail;
+
+    @Schema(description = "동호회 주요 활동 위치", example = "거여동")
+    private String location;
+
+    @Schema(description = "동호회 최대 수용 인원", example = "10")
+    private int limitMemberNumber;
+
+    @Schema(description = "동호회 현재 인원", example = "10")
+    private int currentMemberNumber;
+
+    @Schema(description = "동호회 설명", example = "즐겁게 등산합시다")
+    private String description;
+
+    public static ClubGetResponseDTO from(Club club) {
+        return ClubGetResponseDTO.builder()
+                .clubId(club.getClubId())
+                .name(club.getName())
+                .subjectTitle(club.getSubjectTitle().getTitle())
+                .subjectDetail(club.getSubjectDetail().getDetail())
+                .location(club.getLocation())
+                .limitMemberNumber(club.getLimitMemberNumber())
+                .currentMemberNumber(club.getCurrentMemberNumber())
+                .description(club.getDescription())
+                .build();
+    }
+
+}

--- a/src/main/java/porori/backend/domain/club/model/dto/ClubSubjectResponseDTO.java
+++ b/src/main/java/porori/backend/domain/club/model/dto/ClubSubjectResponseDTO.java
@@ -1,0 +1,28 @@
+package porori.backend.domain.club.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "동호회 주제 Response : 동호회 주제/세부주제 조회 시 얻을 수 있는 정보")
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ClubSubjectResponseDTO {
+
+    @Schema(description = "동호회 주제 이름", example = "여행")
+    private String subjectTitle;
+
+    @Schema(description = "동호회 세부 주제 이름", example = "캠핑")
+    private List<String> subjectDetails;
+
+    public static ClubSubjectResponseDTO of(Map.Entry<String, List<String>> entry) {
+        return ClubSubjectResponseDTO.builder()
+                .subjectTitle(entry.getKey())
+                .subjectDetails(entry.getValue())
+                .build();
+    }
+}

--- a/src/main/java/porori/backend/domain/club/model/dto/ClubUpdateRequestDTO.java
+++ b/src/main/java/porori/backend/domain/club/model/dto/ClubUpdateRequestDTO.java
@@ -1,0 +1,33 @@
+package porori.backend.domain.club.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "동호회 수정 Request : 동호회 수정 시 필요한 정보")
+@NoArgsConstructor
+@Getter
+public class ClubUpdateRequestDTO {
+
+    @Schema(description = "동호회 ID", example = "1")
+    private Long clubId;
+
+    @Schema(description = "동호회 이름", example = "산타는 할아버지")
+    private String name;
+
+    @Schema(description = "동호회 주요 주제", example = "운동")
+    private String subjectTitle;
+
+    @Schema(description = "동호회 세부 주제", example = "하이킹")
+    private String subjectDetail;
+
+    @Schema(description = "동호회 주요 활동 위치", example = "거여동")
+    private String location;
+
+    @Schema(description = "동호회 최대 수용 인원", example = "10")
+    private int limitMemberNumber;
+
+    @Schema(description = "동호회 설명", example = "즐겁게 등산합시다")
+    private String description;
+
+}

--- a/src/main/java/porori/backend/domain/club/model/entity/Club.java
+++ b/src/main/java/porori/backend/domain/club/model/entity/Club.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import porori.backend.domain.member.model.entity.Member;
 import porori.backend.global.common.entity.BaseEntity;
+import porori.backend.global.common.status.BaseStatus;
 
 import javax.persistence.*;
 import java.util.List;
@@ -63,5 +64,9 @@ public class Club extends BaseEntity {
 
     public void increaseCurrentMemberNumber() {
         this.currentMemberNumber = this.currentMemberNumber + 1;
+    }
+
+    public void changeStatus(BaseStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/porori/backend/domain/club/model/entity/Club.java
+++ b/src/main/java/porori/backend/domain/club/model/entity/Club.java
@@ -42,11 +42,14 @@ public class Club extends BaseEntity {
     @Column(nullable = false)
     private int limitMemberNumber;
 
+    @Column(nullable = false)
+    private int currentMemberNumber;
+
     @OneToMany(mappedBy="club")
     private List<Member> members;
 
     @Builder
-    protected Club(Long userId, String name, SubjectTitle subjectTitle, SubjectDetail subjectDetail, String description, String location, int limitMemberNumber) {
+    protected Club(Long userId, String name, SubjectTitle subjectTitle, SubjectDetail subjectDetail, String description, String location, int limitMemberNumber, int currentMemberNumber) {
         this.userId = userId;
         this.name = name;
         this.subjectTitle = subjectTitle;
@@ -54,5 +57,10 @@ public class Club extends BaseEntity {
         this.description = description;
         this.location = location;
         this.limitMemberNumber = limitMemberNumber;
+        this.currentMemberNumber = currentMemberNumber;
+    }
+
+    public void increaseCurrentMemberNumber() {
+        this.currentMemberNumber = this.currentMemberNumber + 1;
     }
 }

--- a/src/main/java/porori/backend/domain/club/model/entity/Club.java
+++ b/src/main/java/porori/backend/domain/club/model/entity/Club.java
@@ -49,7 +49,8 @@ public class Club extends BaseEntity {
     private List<Member> members;
 
     @Builder
-    protected Club(Long userId, String name, SubjectTitle subjectTitle, SubjectDetail subjectDetail, String description, String location, int limitMemberNumber, int currentMemberNumber) {
+    protected Club(Long clubId, Long userId, String name, SubjectTitle subjectTitle, SubjectDetail subjectDetail, String description, String location, int limitMemberNumber, int currentMemberNumber) {
+        this.clubId = clubId;
         this.userId = userId;
         this.name = name;
         this.subjectTitle = subjectTitle;

--- a/src/main/java/porori/backend/domain/club/repository/ClubRepository.java
+++ b/src/main/java/porori/backend/domain/club/repository/ClubRepository.java
@@ -14,4 +14,6 @@ public interface ClubRepository extends JpaRepository<Club, Long> {
     List<Club> findByStatus(BaseStatus status);
 
     List<Club> findBySubjectTitleAndStatus(SubjectTitle subjectTitle, BaseStatus status);
+
+    boolean existsByClubIdAndUserId(Long clubId, Long userId);
 }

--- a/src/main/java/porori/backend/domain/club/repository/ClubRepository.java
+++ b/src/main/java/porori/backend/domain/club/repository/ClubRepository.java
@@ -3,7 +3,12 @@ package porori.backend.domain.club.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import porori.backend.domain.club.model.entity.Club;
+import porori.backend.global.common.status.BaseStatus;
+
+import java.util.List;
 
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long> {
+
+    List<Club> findByStatus(BaseStatus status);
 }

--- a/src/main/java/porori/backend/domain/club/repository/ClubRepository.java
+++ b/src/main/java/porori/backend/domain/club/repository/ClubRepository.java
@@ -3,6 +3,7 @@ package porori.backend.domain.club.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import porori.backend.domain.club.model.entity.Club;
+import porori.backend.domain.club.model.entity.SubjectTitle;
 import porori.backend.global.common.status.BaseStatus;
 
 import java.util.List;
@@ -11,4 +12,6 @@ import java.util.List;
 public interface ClubRepository extends JpaRepository<Club, Long> {
 
     List<Club> findByStatus(BaseStatus status);
+
+    List<Club> findBySubjectTitleAndStatus(SubjectTitle subjectTitle, BaseStatus status);
 }

--- a/src/main/java/porori/backend/domain/club/service/ClubService.java
+++ b/src/main/java/porori/backend/domain/club/service/ClubService.java
@@ -3,10 +3,7 @@ package porori.backend.domain.club.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import porori.backend.domain.club.exception.ClubException;
-import porori.backend.domain.club.model.dto.ClubCreateRequestDTO;
-import porori.backend.domain.club.model.dto.ClubCreateResponseDTO;
-import porori.backend.domain.club.model.dto.ClubGetResponseDTO;
-import porori.backend.domain.club.model.dto.ClubUpdateRequestDTO;
+import porori.backend.domain.club.model.dto.*;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.domain.club.repository.ClubRepository;
 import porori.backend.domain.member.model.entity.Role;
@@ -96,13 +93,24 @@ public class ClubService {
         return ClubGetResponseDTO.from(club);
     }
 
-    private void verifyClubManager(Long clubId, Long userId) {
-        if (!clubRepository.existsByClubIdAndUserId(clubId, userId))
-            throw new ClubException(NOT_MANAGE_CLUB);
-    }
-
     private void verifyCurrentClubMemberNumber(int limitMemberNumber, int currentMemberNumber) {
         if (limitMemberNumber <= currentMemberNumber)
             throw new ClubException(FULL_CLUB_NUMBER);
+    }
+
+    public ClubDeleteResponseDTO deleteClub(String token, Long clubId) {
+        Long userId = userService.getUserId(token);
+
+        Club findClub = clubRepository.findById(clubId).orElseThrow(() -> new ClubException(INVALID_CLUB));
+        verifyClubManager(clubId, userId);
+
+        findClub.changeStatus(BaseStatus.INACTIVE);
+        clubRepository.save(findClub);
+        return ClubDeleteResponseDTO.from(findClub);
+    }
+
+    private void verifyClubManager(Long clubId, Long userId) {
+        if (!clubRepository.existsByClubIdAndUserId(clubId, userId))
+            throw new ClubException(NOT_MANAGE_CLUB);
     }
 }

--- a/src/main/java/porori/backend/domain/club/service/ClubService.java
+++ b/src/main/java/porori/backend/domain/club/service/ClubService.java
@@ -32,6 +32,7 @@ public class ClubService {
                 .description(clubCreateRequestDTO.getDescription())
                 .location(clubCreateRequestDTO.getLocation())
                 .limitMemberNumber(clubCreateRequestDTO.getLimitMemberNumber())
+                .currentMemberNumber(0)
                 .build();
 
         clubRepository.save(club);

--- a/src/main/java/porori/backend/domain/club/service/ClubService.java
+++ b/src/main/java/porori/backend/domain/club/service/ClubService.java
@@ -4,11 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import porori.backend.domain.club.model.dto.ClubCreateRequestDTO;
 import porori.backend.domain.club.model.dto.ClubCreateResponseDTO;
+import porori.backend.domain.club.model.dto.ClubGetResponseDTO;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.domain.club.repository.ClubRepository;
 import porori.backend.domain.member.model.entity.Role;
 import porori.backend.domain.member.service.MemberService;
 import porori.backend.domain.user.service.UserService;
+import porori.backend.global.common.status.BaseStatus;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static porori.backend.domain.club.model.entity.SubjectDetail.valueOfDetail;
 import static porori.backend.domain.club.model.entity.SubjectTitle.valueOfTitle;
@@ -38,5 +43,13 @@ public class ClubService {
         clubRepository.save(club);
         memberService.addMember(club, userId, Role.MANAGER);
         return ClubCreateResponseDTO.from(club);
+    }
+
+    public List<ClubGetResponseDTO> getAllClubs() {
+        List<Club> clubs = clubRepository.findByStatus(BaseStatus.ACTIVE);
+
+        return clubs.stream()
+            .map(ClubGetResponseDTO::from)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/porori/backend/domain/club/service/ClubService.java
+++ b/src/main/java/porori/backend/domain/club/service/ClubService.java
@@ -2,6 +2,7 @@ package porori.backend.domain.club.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import porori.backend.domain.club.exception.ClubException;
 import porori.backend.domain.club.model.dto.ClubCreateRequestDTO;
 import porori.backend.domain.club.model.dto.ClubCreateResponseDTO;
 import porori.backend.domain.club.model.dto.ClubGetResponseDTO;
@@ -16,7 +17,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static porori.backend.domain.club.model.entity.SubjectDetail.valueOfDetail;
+import static porori.backend.domain.club.model.entity.SubjectTitle.EMPTY;
 import static porori.backend.domain.club.model.entity.SubjectTitle.valueOfTitle;
+import static porori.backend.global.common.status.ErrorStatus.INVALID_SUBJECT_TITLE;
 
 @Service
 @RequiredArgsConstructor
@@ -49,7 +52,22 @@ public class ClubService {
         List<Club> clubs = clubRepository.findByStatus(BaseStatus.ACTIVE);
 
         return clubs.stream()
-            .map(ClubGetResponseDTO::from)
-            .collect(Collectors.toList());
+                .map(ClubGetResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<ClubGetResponseDTO> getSubjectClubs(String title) {
+        verifySubjectTitle(title);
+
+        List<Club> clubs = clubRepository.findBySubjectTitleAndStatus(valueOfTitle(title), BaseStatus.ACTIVE);
+
+        return clubs.stream()
+                .map(ClubGetResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    private void verifySubjectTitle(String title) {
+        if (valueOfTitle(title).equals(EMPTY))
+            throw new ClubException(INVALID_SUBJECT_TITLE);
     }
 }

--- a/src/main/java/porori/backend/domain/club/service/ClubService.java
+++ b/src/main/java/porori/backend/domain/club/service/ClubService.java
@@ -5,13 +5,15 @@ import org.springframework.stereotype.Service;
 import porori.backend.domain.club.exception.ClubException;
 import porori.backend.domain.club.model.dto.*;
 import porori.backend.domain.club.model.entity.Club;
+import porori.backend.domain.club.model.entity.SubjectDetail;
+import porori.backend.domain.club.model.entity.SubjectTitle;
 import porori.backend.domain.club.repository.ClubRepository;
 import porori.backend.domain.member.model.entity.Role;
 import porori.backend.domain.member.service.MemberService;
 import porori.backend.domain.user.service.UserService;
 import porori.backend.global.common.status.BaseStatus;
 
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static porori.backend.domain.club.model.entity.SubjectDetail.valueOfDetail;
@@ -44,6 +46,28 @@ public class ClubService {
         clubRepository.save(club);
         memberService.addMember(club, userId, Role.MANAGER);
         return ClubCreateResponseDTO.from(club);
+    }
+
+    public List<ClubSubjectResponseDTO> getClubSubjects() {
+        Map<String, List<String>> map = new HashMap<>();
+        Arrays.stream(SubjectTitle.values())
+                .filter(subjectTitle -> !(subjectTitle.getTitle().equals("")))
+                .forEach(
+                        subjectTitle -> map.put(subjectTitle.getTitle(), new ArrayList<>())
+                );
+
+        Arrays.stream(SubjectDetail.values())
+                .filter(subjectDetail -> !(subjectDetail.getParentSubject() == null))
+                .forEach(
+                        subjectDetail -> {
+                            List<String> details = map.get(subjectDetail.getParentSubject().getTitle());
+                            details.add(subjectDetail.getDetail());
+                        }
+                );
+
+        return map.entrySet().stream()
+                .map(ClubSubjectResponseDTO::of)
+                .collect(Collectors.toList());
     }
 
     public List<ClubGetResponseDTO> getAllClubs() {

--- a/src/main/java/porori/backend/domain/club/service/ClubService.java
+++ b/src/main/java/porori/backend/domain/club/service/ClubService.java
@@ -6,6 +6,7 @@ import porori.backend.domain.club.exception.ClubException;
 import porori.backend.domain.club.model.dto.ClubCreateRequestDTO;
 import porori.backend.domain.club.model.dto.ClubCreateResponseDTO;
 import porori.backend.domain.club.model.dto.ClubGetResponseDTO;
+import porori.backend.domain.club.model.dto.ClubUpdateRequestDTO;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.domain.club.repository.ClubRepository;
 import porori.backend.domain.member.model.entity.Role;
@@ -19,7 +20,7 @@ import java.util.stream.Collectors;
 import static porori.backend.domain.club.model.entity.SubjectDetail.valueOfDetail;
 import static porori.backend.domain.club.model.entity.SubjectTitle.EMPTY;
 import static porori.backend.domain.club.model.entity.SubjectTitle.valueOfTitle;
-import static porori.backend.global.common.status.ErrorStatus.INVALID_SUBJECT_TITLE;
+import static porori.backend.global.common.status.ErrorStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -69,5 +70,39 @@ public class ClubService {
     private void verifySubjectTitle(String title) {
         if (valueOfTitle(title).equals(EMPTY))
             throw new ClubException(INVALID_SUBJECT_TITLE);
+    }
+
+    public ClubGetResponseDTO updateClub(String token, ClubUpdateRequestDTO clubUpdateRequestDTO) {
+        Long userId = userService.getUserId(token);
+        Long clubId = clubUpdateRequestDTO.getClubId();
+
+        Club findClub = clubRepository.findById(clubId).orElseThrow(() -> new ClubException(INVALID_CLUB));
+        verifyClubManager(clubId, userId);
+        verifyCurrentClubMemberNumber(clubUpdateRequestDTO.getLimitMemberNumber(), findClub.getCurrentMemberNumber());
+
+        Club club = Club.builder()
+                .clubId(clubId)
+                .userId(userId)
+                .name(clubUpdateRequestDTO.getName())
+                .subjectTitle(valueOfTitle(clubUpdateRequestDTO.getSubjectTitle()))
+                .subjectDetail(valueOfDetail(clubUpdateRequestDTO.getSubjectDetail()))
+                .description(clubUpdateRequestDTO.getDescription())
+                .location(clubUpdateRequestDTO.getLocation())
+                .limitMemberNumber(clubUpdateRequestDTO.getLimitMemberNumber())
+                .currentMemberNumber(findClub.getCurrentMemberNumber())
+                .build();
+
+        clubRepository.save(club);
+        return ClubGetResponseDTO.from(club);
+    }
+
+    private void verifyClubManager(Long clubId, Long userId) {
+        if (!clubRepository.existsByClubIdAndUserId(clubId, userId))
+            throw new ClubException(NOT_MANAGE_CLUB);
+    }
+
+    private void verifyCurrentClubMemberNumber(int limitMemberNumber, int currentMemberNumber) {
+        if (limitMemberNumber <= currentMemberNumber)
+            throw new ClubException(FULL_CLUB_NUMBER);
     }
 }

--- a/src/main/java/porori/backend/domain/club/service/ClubService.java
+++ b/src/main/java/porori/backend/domain/club/service/ClubService.java
@@ -69,6 +69,12 @@ public class ClubService {
             throw new ClubException(INVALID_SUBJECT_TITLE);
     }
 
+    public ClubGetResponseDTO getClub(Long clubId) {
+        Club findClub = clubRepository.findById(clubId).orElseThrow(() -> new ClubException(INVALID_CLUB));
+
+        return ClubGetResponseDTO.from(findClub);
+    }
+
     public ClubGetResponseDTO updateClub(String token, ClubUpdateRequestDTO clubUpdateRequestDTO) {
         Long userId = userService.getUserId(token);
         Long clubId = clubUpdateRequestDTO.getClubId();

--- a/src/main/java/porori/backend/domain/member/service/MemberService.java
+++ b/src/main/java/porori/backend/domain/member/service/MemberService.java
@@ -2,18 +2,27 @@ package porori.backend.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import porori.backend.domain.club.exception.ClubException;
 import porori.backend.domain.club.model.entity.Club;
+import porori.backend.domain.club.repository.ClubRepository;
 import porori.backend.domain.member.model.entity.Member;
 import porori.backend.domain.member.model.entity.Role;
 import porori.backend.domain.member.repository.MemberRepository;
+
+import static porori.backend.global.common.status.ErrorStatus.INVALID_CLUB;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final ClubRepository clubRepository;
 
     public void addMember(Club club, Long userId, Role role) {
+        Club findClub = clubRepository.findById(club.getClubId()).orElseThrow(() -> new ClubException(INVALID_CLUB));
+        findClub.increaseCurrentMemberNumber();
+        clubRepository.save(findClub);
+
         Member member = Member.builder()
                 .club(club)
                 .userId(userId)

--- a/src/main/java/porori/backend/global/common/entity/BaseEntity.java
+++ b/src/main/java/porori/backend/global/common/entity/BaseEntity.java
@@ -12,8 +12,9 @@ import java.time.format.DateTimeFormatter;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
+
     @Enumerated(EnumType.STRING)
-    private BaseStatus status;
+    protected BaseStatus status;
 
     @CreatedDate
     @Column(updatable = false)

--- a/src/main/java/porori/backend/global/common/status/ErrorStatus.java
+++ b/src/main/java/porori/backend/global/common/status/ErrorStatus.java
@@ -23,7 +23,9 @@ public enum ErrorStatus {
 
     FULL_CLUB_NUMBER(400, "동호회 인원이 모두 찼습니다."),
 
-    INVALID_JWT(401, "유효하지 않은 JWT입니다.");
+    INVALID_JWT(401, "유효하지 않은 JWT입니다."),
+
+    NOT_MANAGE_CLUB(403, "현재 접속한 유저가 관리하는 동호회가 아닙니다.");
 
     private final int statusCode;
     private final String message;

--- a/src/main/java/porori/backend/global/common/status/ErrorStatus.java
+++ b/src/main/java/porori/backend/global/common/status/ErrorStatus.java
@@ -17,6 +17,7 @@ public enum ErrorStatus {
      */
 
     INVALID_CLUB(400, "유효하지 않은 동호회 ID입니다."),
+    INVALID_SUBJECT_TITLE(400, "유효하지 않은 동호회 주제입니다."),
 
     EXIST_APPLICATION(400, "이미 가입 신청한 동호회입니다."),
 

--- a/src/main/java/porori/backend/global/common/status/SuccessStatus.java
+++ b/src/main/java/porori/backend/global/common/status/SuccessStatus.java
@@ -8,6 +8,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SuccessStatus {
 
+    /**
+     * Status Code
+     * 200: OK
+     * 201: CREATED
+     */
+
+
+    SUCCESS(200, "요청이 완료되었습니다."),
+
     CREATE_CLUB(201, "동호회 등록이 완료되었습니다."),
     CREATE_APPLICATION(201, "동호회 신청이 완료되었습니다."),
     CREATE_MEMBER(201, "동호회 멤버 등록이 완료되었습니다.");


### PR DESCRIPTION
## 🔥 Summary
- 동호회 조회
   - ACTIVE한 동호회만 조회 가능하도록
   - Subject에 맞춰서 조회 가능하도록
- 동호회 수정
   - MANAGER인 동호회만 수정 가능하도록
- 동호회 삭제
   - MANAGER인 동호회만 삭제 가능하도록

## ✏️ Describe your changes
동호회 주제(`subjectTitle`)에 따라 필터링하여 조회할 수 있도록 구현
https://github.com/Hey-Porori/Server_Club/blob/ce6334eb4d3e3718cc05a16afff76593564f0afd/src/main/java/porori/backend/domain/club/api/ClubController.java#L39-L41

본인이 관리하는 동호회만 수정 및 삭제 가능하도록 구현
https://github.com/Hey-Porori/Server_Club/blob/ce6334eb4d3e3718cc05a16afff76593564f0afd/src/main/java/porori/backend/domain/club/service/ClubService.java#L112-L115

## 📖 Review Point
동호회 조회 시에는 token이 필요 없다고 생각해서 Header field를 입력받지 않았습니다
https://github.com/Hey-Porori/Server_Club/blob/ce6334eb4d3e3718cc05a16afff76593564f0afd/src/main/java/porori/backend/domain/club/api/ClubController.java#L33
https://github.com/Hey-Porori/Server_Club/blob/ce6334eb4d3e3718cc05a16afff76593564f0afd/src/main/java/porori/backend/domain/club/api/ClubController.java#L39
https://github.com/Hey-Porori/Server_Club/blob/5438739802e8fc65ad0d5017230ccc0a6d01eda3/src/main/java/porori/backend/domain/club/api/ClubController.java#L45


현재는 동호회 주제를 한글로 입력 받아야 하는데 영어가 더 편할까요? (To. 재원)
현재: 한글 -> enumType으로 변경하여(`valueOfTitle` 메소드 사용) find 쿼리문 수행
https://github.com/Hey-Porori/Server_Club/blob/ce6334eb4d3e3718cc05a16afff76593564f0afd/src/main/java/porori/backend/domain/club/service/ClubService.java#L60