### PR TITLE
동호회 가입 수락 및 거절 API

### DIFF
--- a/src/main/java/porori/backend/domain/application/api/ApplicationController.java
+++ b/src/main/java/porori/backend/domain/application/api/ApplicationController.java
@@ -8,8 +8,7 @@ import porori.backend.domain.application.model.dto.ApplicationResponseDTO;
 import porori.backend.domain.application.service.ApplicationService;
 import porori.backend.global.common.dto.response.SuccessResponse;
 
-import static porori.backend.global.common.status.SuccessStatus.ACCEPT_APPLICATION;
-import static porori.backend.global.common.status.SuccessStatus.CREATE_APPLICATION;
+import static porori.backend.global.common.status.SuccessStatus.*;
 
 @Tag(name = "동호회 가입 신청 및 취소 API")
 @RestController
@@ -32,5 +31,13 @@ public class ApplicationController {
                                                                      @PathVariable Long clubId,
                                                                      @PathVariable Long userId) {
         return new SuccessResponse<>(ACCEPT_APPLICATION, applicationService.acceptApplication(token, clubId, userId));
+    }
+
+    @PostMapping("/reject/{clubId}/{userId}")
+    @Operation(summary = "동호회 가입 거절", description = "관리자가 가입 신청한 유저를 거절한다.")
+    public SuccessResponse<ApplicationResponseDTO> rejectApplication(@RequestHeader("Authorization") String token,
+                                                                     @PathVariable Long clubId,
+                                                                     @PathVariable Long userId) {
+        return new SuccessResponse<>(REJECT_APPLICATION, applicationService.rejectApplication(token, clubId, userId));
     }
 }

--- a/src/main/java/porori/backend/domain/application/api/ApplicationController.java
+++ b/src/main/java/porori/backend/domain/application/api/ApplicationController.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import porori.backend.domain.application.model.dto.ApplicationCreateResponseDTO;
+import porori.backend.domain.application.model.dto.ApplicationResponseDTO;
 import porori.backend.domain.application.service.ApplicationService;
 import porori.backend.global.common.dto.response.SuccessResponse;
 
@@ -20,8 +20,8 @@ public class ApplicationController {
 
     @PostMapping("/create")
     @Operation(summary = "동호회 가입 신청", description = "유저가 동호회에 가입 신청을 한다.")
-    public SuccessResponse<ApplicationCreateResponseDTO> createApplication(@RequestHeader("Authorization") String token,
-                                                                           @RequestParam Long clubId) {
+    public SuccessResponse<ApplicationResponseDTO> createApplication(@RequestHeader("Authorization") String token,
+                                                                     @RequestParam Long clubId) {
         return new SuccessResponse<>(CREATE_APPLICATION, applicationService.createApplication(token, clubId));
     }
 }

--- a/src/main/java/porori/backend/domain/application/api/ApplicationController.java
+++ b/src/main/java/porori/backend/domain/application/api/ApplicationController.java
@@ -30,7 +30,7 @@ public class ApplicationController {
     public SuccessResponse<ApplicationResponseDTO> acceptApplication(@RequestHeader("Authorization") String token,
                                                                      @PathVariable Long clubId,
                                                                      @PathVariable Long userId) {
-        return new SuccessResponse<>(ACCEPT_APPLICATION, applicationService.acceptApplication(token, clubId, userId));
+        return new SuccessResponse<>(SUCCESS, applicationService.acceptApplication(token, clubId, userId));
     }
 
     @PostMapping("/reject/{clubId}/{userId}")
@@ -38,6 +38,6 @@ public class ApplicationController {
     public SuccessResponse<ApplicationResponseDTO> rejectApplication(@RequestHeader("Authorization") String token,
                                                                      @PathVariable Long clubId,
                                                                      @PathVariable Long userId) {
-        return new SuccessResponse<>(REJECT_APPLICATION, applicationService.rejectApplication(token, clubId, userId));
+        return new SuccessResponse<>(SUCCESS, applicationService.rejectApplication(token, clubId, userId));
     }
 }

--- a/src/main/java/porori/backend/domain/application/api/ApplicationController.java
+++ b/src/main/java/porori/backend/domain/application/api/ApplicationController.java
@@ -18,10 +18,10 @@ public class ApplicationController {
 
     private final ApplicationService applicationService;
 
-    @PostMapping("/create")
+    @PostMapping("/create/{clubId}")
     @Operation(summary = "동호회 가입 신청", description = "유저가 동호회에 가입 신청을 한다.")
     public SuccessResponse<ApplicationResponseDTO> createApplication(@RequestHeader("Authorization") String token,
-                                                                     @RequestParam Long clubId) {
+                                                                     @PathVariable Long clubId) {
         return new SuccessResponse<>(CREATE_APPLICATION, applicationService.createApplication(token, clubId));
     }
 

--- a/src/main/java/porori/backend/domain/application/api/ApplicationController.java
+++ b/src/main/java/porori/backend/domain/application/api/ApplicationController.java
@@ -8,6 +8,8 @@ import porori.backend.domain.application.model.dto.ApplicationResponseDTO;
 import porori.backend.domain.application.service.ApplicationService;
 import porori.backend.global.common.dto.response.SuccessResponse;
 
+import java.util.List;
+
 import static porori.backend.global.common.status.SuccessStatus.*;
 
 @Tag(name = "동호회 가입 신청 및 취소 API")
@@ -39,5 +41,12 @@ public class ApplicationController {
                                                                      @PathVariable Long clubId,
                                                                      @PathVariable Long userId) {
         return new SuccessResponse<>(SUCCESS, applicationService.rejectApplication(token, clubId, userId));
+    }
+
+    @GetMapping("/list/{clubId}")
+    @Operation(summary = "동호회 가입 신청자 확인", description = "관리자가 가입 신청한 유저 목록을 조회한다.")
+    public SuccessResponse<List<ApplicationResponseDTO>> getApplicationList(@RequestHeader("Authorization") String token,
+                                                                            @PathVariable Long clubId) {
+        return new SuccessResponse<>(SUCCESS, applicationService.getApplicationList(token, clubId));
     }
 }

--- a/src/main/java/porori/backend/domain/application/api/ApplicationController.java
+++ b/src/main/java/porori/backend/domain/application/api/ApplicationController.java
@@ -8,6 +8,7 @@ import porori.backend.domain.application.model.dto.ApplicationResponseDTO;
 import porori.backend.domain.application.service.ApplicationService;
 import porori.backend.global.common.dto.response.SuccessResponse;
 
+import static porori.backend.global.common.status.SuccessStatus.ACCEPT_APPLICATION;
 import static porori.backend.global.common.status.SuccessStatus.CREATE_APPLICATION;
 
 @Tag(name = "동호회 가입 신청 및 취소 API")
@@ -23,5 +24,13 @@ public class ApplicationController {
     public SuccessResponse<ApplicationResponseDTO> createApplication(@RequestHeader("Authorization") String token,
                                                                      @RequestParam Long clubId) {
         return new SuccessResponse<>(CREATE_APPLICATION, applicationService.createApplication(token, clubId));
+    }
+
+    @PostMapping("/accept/{clubId}/{userId}")
+    @Operation(summary = "동호회 가입 수락", description = "관리자가 가입 신청한 유저를 수락한다.")
+    public SuccessResponse<ApplicationResponseDTO> acceptApplication(@RequestHeader("Authorization") String token,
+                                                                     @PathVariable Long clubId,
+                                                                     @PathVariable Long userId) {
+        return new SuccessResponse<>(ACCEPT_APPLICATION, applicationService.acceptApplication(token, clubId, userId));
     }
 }

--- a/src/main/java/porori/backend/domain/application/model/dto/ApplicationResponseDTO.java
+++ b/src/main/java/porori/backend/domain/application/model/dto/ApplicationResponseDTO.java
@@ -10,7 +10,7 @@ import porori.backend.domain.application.model.entity.ApplicationStatus;
 @Schema(description = "동호회 가입 신청 Response : 동호회 가입 신청 후 얻을 수 있는 정보")
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
-public class ApplicationCreateResponseDTO {
+public class ApplicationResponseDTO {
 
     @Schema(description = "유저 ID", example = "1")
     private Long userId;
@@ -21,8 +21,8 @@ public class ApplicationCreateResponseDTO {
     @Schema(description = "지원 상태", example = "APPLIED")
     private ApplicationStatus applicationStatus;
 
-    public static ApplicationCreateResponseDTO from(Application application) {
-        return ApplicationCreateResponseDTO.builder()
+    public static ApplicationResponseDTO from(Application application) {
+        return ApplicationResponseDTO.builder()
                 .userId(application.getUserId())
                 .clubId(application.getClub().getClubId())
                 .applicationStatus(application.getApplicationStatus())

--- a/src/main/java/porori/backend/domain/application/model/entity/Application.java
+++ b/src/main/java/porori/backend/domain/application/model/entity/Application.java
@@ -36,4 +36,8 @@ public class Application extends BaseEntity {
         this.userId = userId;
         this.applicationStatus = applicationStatus;
     }
+
+    public void changeStatus(ApplicationStatus status) {
+        this.applicationStatus = status;
+    }
 }

--- a/src/main/java/porori/backend/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/porori/backend/domain/application/repository/ApplicationRepository.java
@@ -3,14 +3,18 @@ package porori.backend.domain.application.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import porori.backend.domain.application.model.entity.Application;
+import porori.backend.domain.application.model.entity.ApplicationStatus;
 import porori.backend.domain.club.model.entity.Club;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
 
     Optional<Application> findByClubAndUserId(Club club, Long userId);
+
+    List<Application> findByClubAndApplicationStatus(Club club, ApplicationStatus applicationStatus);
 
     boolean existsByClubAndUserId(Club club, Long userId);
 }

--- a/src/main/java/porori/backend/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/porori/backend/domain/application/repository/ApplicationRepository.java
@@ -5,8 +5,12 @@ import org.springframework.stereotype.Repository;
 import porori.backend.domain.application.model.entity.Application;
 import porori.backend.domain.club.model.entity.Club;
 
+import java.util.Optional;
+
 @Repository
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
+
+    Optional<Application> findByClubAndUserId(Club club, Long userId);
 
     boolean existsByClubAndUserId(Club club, Long userId);
 }

--- a/src/main/java/porori/backend/domain/application/service/ApplicationService.java
+++ b/src/main/java/porori/backend/domain/application/service/ApplicationService.java
@@ -15,8 +15,10 @@ import porori.backend.domain.member.repository.MemberRepository;
 import porori.backend.domain.member.service.MemberService;
 import porori.backend.domain.user.service.UserService;
 
-import static porori.backend.domain.application.model.entity.ApplicationStatus.COMPLETED;
-import static porori.backend.domain.application.model.entity.ApplicationStatus.REJECTED;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static porori.backend.domain.application.model.entity.ApplicationStatus.*;
 import static porori.backend.global.common.status.ErrorStatus.*;
 
 @Service
@@ -85,6 +87,16 @@ public class ApplicationService {
         if (!clubRepository.existsByClubIdAndUserId(clubId, userId))
             throw new ClubException(NOT_MANAGE_CLUB);
         return clubRepository.findById(clubId).orElseThrow(() -> new ClubException(INVALID_CLUB));
+    }
+
+    public List<ApplicationResponseDTO> getApplicationList(String token, Long clubId) {
+        Long userId = userService.getUserId(token);
+        Club club = verifyClubManager(clubId, userId);
+
+        List<Application> applications = applicationRepository.findByClubAndApplicationStatus(club, APPLIED);
+        return applications.stream()
+                .map(ApplicationResponseDTO::from)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/porori/backend/domain/application/service/ApplicationService.java
+++ b/src/main/java/porori/backend/domain/application/service/ApplicationService.java
@@ -16,6 +16,7 @@ import porori.backend.domain.member.service.MemberService;
 import porori.backend.domain.user.service.UserService;
 
 import static porori.backend.domain.application.model.entity.ApplicationStatus.COMPLETED;
+import static porori.backend.domain.application.model.entity.ApplicationStatus.REJECTED;
 import static porori.backend.global.common.status.ErrorStatus.*;
 
 @Service
@@ -68,6 +69,20 @@ public class ApplicationService {
         applicationRepository.save(application);
 
         memberService.addMember(club, userId, Role.MEMBER);
+
+        return ApplicationResponseDTO.from(application);
+    }
+
+    public ApplicationResponseDTO rejectApplication(String token, Long clubId, Long userId) {
+        Long managerId = userService.getUserId(token);
+        Club club = clubRepository.findById(clubId).orElseThrow(() -> new ClubException(INVALID_CLUB));
+
+        verifyClubManager(clubId, managerId);
+
+        Application application = applicationRepository.findByClubAndUserId(club, userId).orElseThrow(() -> new ApplicationException(NOT_EXIST_APPLICATION));
+
+        application.changeStatus(REJECTED);
+        applicationRepository.save(application);
 
         return ApplicationResponseDTO.from(application);
     }

--- a/src/main/java/porori/backend/domain/application/service/ApplicationService.java
+++ b/src/main/java/porori/backend/domain/application/service/ApplicationService.java
@@ -3,7 +3,7 @@ package porori.backend.domain.application.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import porori.backend.domain.application.exception.ApplicationException;
-import porori.backend.domain.application.model.dto.ApplicationCreateResponseDTO;
+import porori.backend.domain.application.model.dto.ApplicationResponseDTO;
 import porori.backend.domain.application.model.entity.Application;
 import porori.backend.domain.application.model.entity.ApplicationStatus;
 import porori.backend.domain.application.repository.ApplicationRepository;
@@ -25,7 +25,7 @@ public class ApplicationService {
     private final ClubRepository clubRepository;
     private final MemberRepository memberRepository;
 
-    public ApplicationCreateResponseDTO createApplication(String token, Long clubId) {
+    public ApplicationResponseDTO createApplication(String token, Long clubId) {
         Long userId = userService.getUserId(token);
         Club club = clubRepository.findById(clubId).orElseThrow(() -> new ClubException(INVALID_CLUB));
 
@@ -39,7 +39,7 @@ public class ApplicationService {
                 .build();
 
         applicationRepository.save(application);
-        return ApplicationCreateResponseDTO.from(application);
+        return ApplicationResponseDTO.from(application);
     }
 
     private void verifyAlreadyApplied(Club club, Long userId) {

--- a/src/main/java/porori/backend/domain/application/service/ApplicationService.java
+++ b/src/main/java/porori/backend/domain/application/service/ApplicationService.java
@@ -10,9 +10,9 @@ import porori.backend.domain.application.repository.ApplicationRepository;
 import porori.backend.domain.club.exception.ClubException;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.domain.club.repository.ClubRepository;
-import porori.backend.domain.member.model.entity.Member;
 import porori.backend.domain.member.model.entity.Role;
 import porori.backend.domain.member.repository.MemberRepository;
+import porori.backend.domain.member.service.MemberService;
 import porori.backend.domain.user.service.UserService;
 
 import static porori.backend.domain.application.model.entity.ApplicationStatus.COMPLETED;
@@ -23,6 +23,7 @@ import static porori.backend.global.common.status.ErrorStatus.*;
 public class ApplicationService {
 
     private final UserService userService;
+    private final MemberService memberService;
 
     private final ApplicationRepository applicationRepository;
     private final ClubRepository clubRepository;
@@ -66,12 +67,7 @@ public class ApplicationService {
         application.changeStatus(COMPLETED);
         applicationRepository.save(application);
 
-        Member member = Member.builder()
-                .club(club)
-                .userId(userId)
-                .role(Role.MEMBER)
-                .build();
-        memberRepository.save(member);
+        memberService.addMember(club, userId, Role.MEMBER);
 
         return ApplicationResponseDTO.from(application);
     }

--- a/src/main/java/porori/backend/global/common/status/ErrorStatus.java
+++ b/src/main/java/porori/backend/global/common/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus {
     INVALID_SUBJECT_TITLE(400, "유효하지 않은 동호회 주제입니다."),
 
     EXIST_APPLICATION(400, "이미 가입 신청한 동호회입니다."),
+    NOT_EXIST_APPLICATION(400, "신청 내역이 존재하지 않습니다."),
 
     FULL_CLUB_NUMBER(400, "동호회 인원이 모두 찼습니다."),
 

--- a/src/main/java/porori/backend/global/common/status/SuccessStatus.java
+++ b/src/main/java/porori/backend/global/common/status/SuccessStatus.java
@@ -17,9 +17,6 @@ public enum SuccessStatus {
 
     SUCCESS(200, "요청이 완료되었습니다."),
 
-    ACCEPT_APPLICATION(200, "신청 수락이 완료되었습니다."),
-    REJECT_APPLICATION(200, "신청 거절이 완료되었습니다."),
-
     CREATE_CLUB(201, "동호회 등록이 완료되었습니다."),
     CREATE_APPLICATION(201, "동호회 신청이 완료되었습니다."),
     CREATE_MEMBER(201, "동호회 멤버 등록이 완료되었습니다.");

--- a/src/main/java/porori/backend/global/common/status/SuccessStatus.java
+++ b/src/main/java/porori/backend/global/common/status/SuccessStatus.java
@@ -17,6 +17,8 @@ public enum SuccessStatus {
 
     SUCCESS(200, "요청이 완료되었습니다."),
 
+    ACCEPT_APPLICATION(200, "신청 수락이 완료되었습니다."),
+
     CREATE_CLUB(201, "동호회 등록이 완료되었습니다."),
     CREATE_APPLICATION(201, "동호회 신청이 완료되었습니다."),
     CREATE_MEMBER(201, "동호회 멤버 등록이 완료되었습니다.");

--- a/src/main/java/porori/backend/global/common/status/SuccessStatus.java
+++ b/src/main/java/porori/backend/global/common/status/SuccessStatus.java
@@ -18,6 +18,7 @@ public enum SuccessStatus {
     SUCCESS(200, "요청이 완료되었습니다."),
 
     ACCEPT_APPLICATION(200, "신청 수락이 완료되었습니다."),
+    REJECT_APPLICATION(200, "신청 거절이 완료되었습니다."),
 
     CREATE_CLUB(201, "동호회 등록이 완료되었습니다."),
     CREATE_APPLICATION(201, "동호회 신청이 완료되었습니다."),

--- a/src/main/java/porori/backend/global/config/swagger/OpenApiConfig.java
+++ b/src/main/java/porori/backend/global/config/swagger/OpenApiConfig.java
@@ -3,28 +3,32 @@ package porori.backend.global.config.swagger;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Arrays;
+
 @Configuration
 public class OpenApiConfig {
+
+    @Value("${service.club}")
+    private String clubUrl;
+
     @Bean
     public OpenAPI openAPI() {
 
-//        Server devServer = new Server();
-//        devServer.setDescription("dev");
-//        devServer.setUrl("OUR_DOMAIN");
+        Server devServer = new Server();
+        devServer.setDescription("dev");
+        devServer.setUrl(clubUrl);
 
         Server localServer = new Server();
         localServer.setDescription("local");
-        localServer.setUrl("http://localhost:8082");
+        localServer.setUrl("http://localhost:8080");
 
-//        return new OpenAPI()
-//                .info(getInfo())
-//                .servers(Arrays.asList(devServer, localServer));
         return new OpenAPI()
-                .info(getInfo());
-
+                .info(getInfo())
+                .servers(Arrays.asList(devServer, localServer));
     }
 
     private Info getInfo() {


### PR DESCRIPTION
## 🔥 Summary
- 동호회 가입 수락 API
- 동호회 가입 거절 API
- 동호회 가입 신청자 조회 API

## ✏️ Describe your changes
수락 로직과 거절 로직의 공통되는 부분을 뽑아 함께 사용함으로써 코드 중복 제거
https://github.com/Hey-Porori/Server_Club/blob/85120944f6522874b3cd07ece0a02bbfd40ed48a/src/main/java/porori/backend/domain/application/service/ApplicationService.java#L79-L84

본인이 관리하는 동호회만 회원 수락 및 거절이 가능하도록 구현
https://github.com/Hey-Porori/Server_Club/blob/85120944f6522874b3cd07ece0a02bbfd40ed48a/src/main/java/porori/backend/domain/application/service/ApplicationService.java#L63-L64

## 📖 Review Point
지원 상태가 `APPLIED `인 회원만 조회가능합니다
이미 수락했거나 거절한 회원은 조회 불가능
https://github.com/Hey-Porori/Server_Club/blob/85120944f6522874b3cd07ece0a02bbfd40ed48a/src/main/java/porori/backend/domain/application/service/ApplicationService.java#L96