### PR TITLE
회원 목록 조회 & 회원 강제 탈퇴 API

### DIFF
--- a/src/main/java/porori/backend/domain/application/service/ApplicationService.java
+++ b/src/main/java/porori/backend/domain/application/service/ApplicationService.java
@@ -30,7 +30,6 @@ public class ApplicationService {
 
     private final ApplicationRepository applicationRepository;
     private final ClubRepository clubRepository;
-    private final MemberRepository memberRepository;
 
     public ApplicationResponseDTO createApplication(String token, Long clubId) {
         Long userId = userService.getUserId(token);
@@ -55,7 +54,7 @@ public class ApplicationService {
     }
 
     private void verifyClubLimitMember(Club club) {
-        if (memberRepository.findByClub(club).size() >= club.getLimitMemberNumber())
+        if (club.getCurrentMemberNumber() >= club.getLimitMemberNumber())
             throw new ApplicationException(FULL_CLUB_NUMBER);
     }
 

--- a/src/main/java/porori/backend/domain/member/api/MemberController.java
+++ b/src/main/java/porori/backend/domain/member/api/MemberController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import porori.backend.domain.member.model.dto.MemberResponseDTO;
+import porori.backend.domain.member.model.dto.MemberStatusResponseDTO;
 import porori.backend.domain.member.service.MemberService;
 import porori.backend.global.common.dto.response.SuccessResponse;
 
@@ -25,6 +26,14 @@ public class MemberController {
     public SuccessResponse<List<MemberResponseDTO>> getMemberList(@RequestHeader("Authorization") String token,
                                                                   @PathVariable Long clubId) {
         return new SuccessResponse<>(SUCCESS, memberService.getMemberList(token, clubId));
+    }
+
+    @PostMapping("/kick-out/{clubId}/{userId}")
+    @Operation(summary = "동호회 회원 강제 탈퇴", description = "관리자가 회원을 강제 탈퇴한다.")
+    public SuccessResponse<MemberStatusResponseDTO> kickOutMember(@RequestHeader("Authorization") String token,
+                                                                  @PathVariable Long clubId,
+                                                                  @PathVariable Long userId) {
+        return new SuccessResponse<>(SUCCESS, memberService.kickOutMember(token, clubId, userId));
     }
 
 }

--- a/src/main/java/porori/backend/domain/member/api/MemberController.java
+++ b/src/main/java/porori/backend/domain/member/api/MemberController.java
@@ -1,0 +1,30 @@
+package porori.backend.domain.member.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import porori.backend.domain.member.model.dto.MemberResponseDTO;
+import porori.backend.domain.member.service.MemberService;
+import porori.backend.global.common.dto.response.SuccessResponse;
+
+import java.util.List;
+
+import static porori.backend.global.common.status.SuccessStatus.SUCCESS;
+
+@Tag(name = "동호회 멤버 API")
+@RestController
+@RequestMapping("/api/clubs/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/list/{clubId}")
+    @Operation(summary = "동호회 회원 확인", description = "관리자가 동호회 회원 목록을 조회한다.")
+    public SuccessResponse<List<MemberResponseDTO>> getMemberList(@RequestHeader("Authorization") String token,
+                                                                  @PathVariable Long clubId) {
+        return new SuccessResponse<>(SUCCESS, memberService.getMemberList(token, clubId));
+    }
+
+}

--- a/src/main/java/porori/backend/domain/member/exception/MemberException.java
+++ b/src/main/java/porori/backend/domain/member/exception/MemberException.java
@@ -1,0 +1,10 @@
+package porori.backend.domain.member.exception;
+
+import porori.backend.global.common.status.ErrorStatus;
+import porori.backend.global.error.exception.BaseException;
+
+public class MemberException extends BaseException {
+    public MemberException(ErrorStatus error) {
+        super(error);
+    }
+}

--- a/src/main/java/porori/backend/domain/member/model/dto/MemberResponseDTO.java
+++ b/src/main/java/porori/backend/domain/member/model/dto/MemberResponseDTO.java
@@ -1,10 +1,10 @@
 package porori.backend.domain.member.model.dto;
 
+import com.google.gson.JsonObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import porori.backend.domain.member.model.entity.Member;
 
 @Schema(description = "동호회 회원 조회 Response : 동호회 회원 조회 시 얻을 수 있는 정보")
 @Builder(access = AccessLevel.PRIVATE)
@@ -20,10 +20,11 @@ public class MemberResponseDTO {
     @Schema(description = "유저 프로필 이미지 URL", example = "profile.png")
     private String imageUrl;
 
-    // todo: userId로 정보를 얻어와서 DTO로 변환
-    public static MemberResponseDTO from(Member member) {
+    public static MemberResponseDTO from(JsonObject userInfo) {
         return MemberResponseDTO.builder()
-                .userId(member.getUserId())
+                .userId(userInfo.get("userId").getAsLong())
+                .nickName(userInfo.get("nickname").getAsString())
+                .imageUrl(userInfo.get("image").getAsString())
                 .build();
     }
 }

--- a/src/main/java/porori/backend/domain/member/model/dto/MemberResponseDTO.java
+++ b/src/main/java/porori/backend/domain/member/model/dto/MemberResponseDTO.java
@@ -1,0 +1,29 @@
+package porori.backend.domain.member.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import porori.backend.domain.member.model.entity.Member;
+
+@Schema(description = "동호회 회원 조회 Response : 동호회 회원 조회 시 얻을 수 있는 정보")
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class MemberResponseDTO {
+
+    @Schema(description = "유저 ID", example = "1")
+    private Long userId;
+
+    @Schema(description = "유저 닉네임", example = "홍길동")
+    private String nickName;
+
+    @Schema(description = "유저 프로필 이미지 URL", example = "profile.png")
+    private String imageUrl;
+
+    // todo: userId로 정보를 얻어와서 DTO로 변환
+    public static MemberResponseDTO from(Member member) {
+        return MemberResponseDTO.builder()
+                .userId(member.getUserId())
+                .build();
+    }
+}

--- a/src/main/java/porori/backend/domain/member/model/dto/MemberStatusResponseDTO.java
+++ b/src/main/java/porori/backend/domain/member/model/dto/MemberStatusResponseDTO.java
@@ -1,0 +1,26 @@
+package porori.backend.domain.member.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import porori.backend.domain.member.model.entity.Member;
+
+@Schema(description = "동호회 회원 탈퇴 Response : 동호회 회원 탈퇴 시 얻을 수 있는 정보")
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class MemberStatusResponseDTO {
+
+    @Schema(description = "동호회 ID", example = "1")
+    private Long clubId;
+
+    @Schema(description = "유저 ID", example = "1")
+    private Long userId;
+
+    public static MemberStatusResponseDTO from(Member member) {
+        return MemberStatusResponseDTO.builder()
+                .clubId(member.getClub().getClubId())
+                .userId(member.getUserId())
+                .build();
+    }
+}

--- a/src/main/java/porori/backend/domain/member/model/entity/Member.java
+++ b/src/main/java/porori/backend/domain/member/model/entity/Member.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.global.common.entity.BaseEntity;
+import porori.backend.global.common.status.BaseStatus;
 
 import javax.persistence.*;
 
@@ -33,5 +34,9 @@ public class Member extends BaseEntity {
         this.userId = userId;
         this.club = club;
         this.role = role;
+    }
+
+    public void changeStatus(BaseStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/porori/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/porori/backend/domain/member/repository/MemberRepository.java
@@ -4,11 +4,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.domain.member.model.entity.Member;
+import porori.backend.global.common.status.BaseStatus;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    List<Member> findByClub(Club club);
+    List<Member> findByClubAndStatus(Club club, BaseStatus status);
+
+    Optional<Member> findByClubAndUserId(Club club, Long userId);
 }

--- a/src/main/java/porori/backend/domain/member/service/MemberService.java
+++ b/src/main/java/porori/backend/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package porori.backend.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import porori.backend.domain.application.exception.ApplicationException;
 import porori.backend.domain.club.exception.ClubException;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.domain.club.repository.ClubRepository;
@@ -14,8 +15,7 @@ import porori.backend.domain.user.service.UserService;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static porori.backend.global.common.status.ErrorStatus.INVALID_CLUB;
-import static porori.backend.global.common.status.ErrorStatus.NOT_MANAGE_CLUB;
+import static porori.backend.global.common.status.ErrorStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +28,7 @@ public class MemberService {
 
     public void addMember(Club club, Long userId, Role role) {
         Club findClub = clubRepository.findById(club.getClubId()).orElseThrow(() -> new ClubException(INVALID_CLUB));
+        verifyClubLimitMember(findClub);
         findClub.increaseCurrentMemberNumber();
         clubRepository.save(findClub);
 
@@ -38,6 +39,11 @@ public class MemberService {
                 .build();
 
         memberRepository.save(member);
+    }
+
+    private void verifyClubLimitMember(Club club) {
+        if (club.getCurrentMemberNumber() >= club.getLimitMemberNumber())
+            throw new ApplicationException(FULL_CLUB_NUMBER);
     }
 
     public List<MemberResponseDTO> getMemberList(String token, Long clubId) {

--- a/src/main/java/porori/backend/domain/member/service/MemberService.java
+++ b/src/main/java/porori/backend/domain/member/service/MemberService.java
@@ -5,15 +5,23 @@ import org.springframework.stereotype.Service;
 import porori.backend.domain.club.exception.ClubException;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.domain.club.repository.ClubRepository;
+import porori.backend.domain.member.model.dto.MemberResponseDTO;
 import porori.backend.domain.member.model.entity.Member;
 import porori.backend.domain.member.model.entity.Role;
 import porori.backend.domain.member.repository.MemberRepository;
+import porori.backend.domain.user.service.UserService;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static porori.backend.global.common.status.ErrorStatus.INVALID_CLUB;
+import static porori.backend.global.common.status.ErrorStatus.NOT_MANAGE_CLUB;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
+
+    private final UserService userService;
 
     private final MemberRepository memberRepository;
     private final ClubRepository clubRepository;
@@ -30,5 +38,21 @@ public class MemberService {
                 .build();
 
         memberRepository.save(member);
+    }
+
+    public List<MemberResponseDTO> getMemberList(String token, Long clubId) {
+        Long managerId = userService.getUserId(token);
+        Club club = verifyClubManager(clubId, managerId);
+
+        List<Member> members = memberRepository.findByClub(club);
+        return members.stream()
+                .map(MemberResponseDTO::from)
+                .collect(Collectors.toList());
+    }
+
+    private Club verifyClubManager(Long clubId, Long userId) {
+        if (!clubRepository.existsByClubIdAndUserId(clubId, userId))
+            throw new ClubException(NOT_MANAGE_CLUB);
+        return clubRepository.findById(clubId).orElseThrow(() -> new ClubException(INVALID_CLUB));
     }
 }

--- a/src/main/java/porori/backend/domain/member/service/MemberService.java
+++ b/src/main/java/porori/backend/domain/member/service/MemberService.java
@@ -55,9 +55,7 @@ public class MemberService {
         Club club = verifyClubManager(clubId, managerId);
 
         List<Member> members = memberRepository.findByClubAndStatus(club, ACTIVE);
-        return members.stream()
-                .map(MemberResponseDTO::from)
-                .collect(Collectors.toList());
+        return userService.getMemberResponseDTO(members.stream().map(Member::getUserId).collect(Collectors.toList()));
     }
 
     private Club verifyClubManager(Long clubId, Long userId) {

--- a/src/main/java/porori/backend/domain/user/service/UserService.java
+++ b/src/main/java/porori/backend/domain/user/service/UserService.java
@@ -1,12 +1,17 @@
 package porori.backend.domain.user.service;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import porori.backend.domain.member.model.dto.MemberResponseDTO;
 import porori.backend.domain.user.exception.UserException;
 import porori.backend.global.common.status.ErrorStatus;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +40,41 @@ public class UserService {
         JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
         JsonObject data = jsonObject.getAsJsonObject("data");
         return data.get("userId").getAsLong();
+    }
+
+    public List<MemberResponseDTO> getMemberResponseDTO(List<Long> userIds) {
+        String response = sendCommunitiesInfoRequest(userIds);
+        return extractUserInfoFromResponse(response);
+    }
+
+    private String sendCommunitiesInfoRequest(List<Long> userIds) {
+        try {
+            StringBuilder userIdList = new StringBuilder("/communities/info?userIdList=");
+            for (Long userId : userIds) {
+                userIdList.append(userId).append(",");
+            }
+            userIdList.delete(userIdList.length() - 1, userIdList.length());
+
+            return webClient.get()
+                    .uri(userIdList.toString())
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+        } catch (Exception e) {
+            throw new UserException(ErrorStatus.NOT_EXIST_USER);
+        }
+    }
+
+    private List<MemberResponseDTO> extractUserInfoFromResponse(String response) {
+        JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
+        JsonObject data = jsonObject.getAsJsonObject("data");
+
+        List<MemberResponseDTO> memberResponseDTOs = new ArrayList<>();
+        for (JsonElement element : data.getAsJsonArray("communityUserInfoBlocks")) {
+            JsonObject userInfo = element.getAsJsonObject();
+            memberResponseDTOs.add(MemberResponseDTO.from(userInfo));
+        }
+        return memberResponseDTOs;
     }
 
 }

--- a/src/main/java/porori/backend/global/common/status/ErrorStatus.java
+++ b/src/main/java/porori/backend/global/common/status/ErrorStatus.java
@@ -20,13 +20,15 @@ public enum ErrorStatus {
     INVALID_SUBJECT_TITLE(400, "유효하지 않은 동호회 주제입니다."),
 
     EXIST_APPLICATION(400, "이미 가입 신청한 동호회입니다."),
-    NOT_EXIST_APPLICATION(400, "신청 내역이 존재하지 않습니다."),
 
     FULL_CLUB_NUMBER(400, "동호회 인원이 모두 찼습니다."),
 
     INVALID_JWT(401, "유효하지 않은 JWT입니다."),
 
-    NOT_MANAGE_CLUB(403, "현재 접속한 유저가 관리하는 동호회가 아닙니다.");
+    NOT_MANAGE_CLUB(403, "현재 접속한 유저가 관리하는 동호회가 아닙니다."),
+
+    NOT_EXIST_APPLICATION(404, "신청 내역이 존재하지 않습니다."),
+    NOT_EXIST_MEMBER(404, "동호회 회원이 아닙니다.");
 
     private final int statusCode;
     private final String message;

--- a/src/main/java/porori/backend/global/common/status/ErrorStatus.java
+++ b/src/main/java/porori/backend/global/common/status/ErrorStatus.java
@@ -28,7 +28,8 @@ public enum ErrorStatus {
     NOT_MANAGE_CLUB(403, "현재 접속한 유저가 관리하는 동호회가 아닙니다."),
 
     NOT_EXIST_APPLICATION(404, "신청 내역이 존재하지 않습니다."),
-    NOT_EXIST_MEMBER(404, "동호회 회원이 아닙니다.");
+    NOT_EXIST_MEMBER(404, "동호회 회원이 아닙니다."),
+    NOT_EXIST_USER(404, "유저 정보가 존재하지 않습니다.");
 
     private final int statusCode;
     private final String message;

--- a/src/main/java/porori/backend/global/error/exception/GlobalExceptionHandler.java
+++ b/src/main/java/porori/backend/global/error/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import porori.backend.domain.application.exception.ApplicationException;
 import porori.backend.domain.club.exception.ClubException;
+import porori.backend.domain.member.exception.MemberException;
 import porori.backend.domain.user.exception.UserException;
 import porori.backend.global.common.dto.response.FailResponse;
 
@@ -29,6 +30,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({ApplicationException.class})
     protected ResponseEntity<FailResponse> handleApplicationException(ApplicationException exception) {
+        return ResponseEntity.status(HttpStatus.valueOf(exception.getError().getStatusCode())).body(new FailResponse(exception.getError()));
+    }
+
+    @ExceptionHandler({MemberException.class})
+    protected ResponseEntity<FailResponse> handleMemberException(ApplicationException exception) {
         return ResponseEntity.status(HttpStatus.valueOf(exception.getError().getStatusCode())).body(new FailResponse(exception.getError()));
     }
 }


### PR DESCRIPTION
## 🔥 Summary
- 회원 목록 조회 API
- 회원 강제 탈퇴 API

## ✏️ Describe your changes
유저 강제 탈퇴 시 soft delete 사용 (그냥 탈퇴 시에도 적용 예정)
https://github.com/Hey-Porori/Server_Club/blob/bf17c20eccefae5a598621ed991aa8491e9666dc/src/main/java/porori/backend/domain/member/service/MemberService.java#L75

## 📖 Review Point
Club Server도 유저 ID로 정보를 얻어 오는 로직이 필요합니다!!
회원 목록을 조회할 때 Club Server가 가진 정보가 유저 ID 밖에 없어요
`/api/users/communities/info` 쪽 변동 없다면 이거 써도 됩니다
(api 새로 만드는 것보다 이름 바꿔서 범용적으로 사용하는 게 좋을 것 같아요)
https://github.com/Hey-Porori/Server_Club/blob/bf17c20eccefae5a598621ed991aa8491e9666dc/src/main/java/porori/backend/domain/member/model/dto/MemberResponseDTO.java#L14-L21