### PR TITLE
동호회 탈퇴 API

### DIFF
--- a/src/main/java/porori/backend/domain/application/service/ApplicationService.java
+++ b/src/main/java/porori/backend/domain/application/service/ApplicationService.java
@@ -11,7 +11,6 @@ import porori.backend.domain.club.exception.ClubException;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.domain.club.repository.ClubRepository;
 import porori.backend.domain.member.model.entity.Role;
-import porori.backend.domain.member.repository.MemberRepository;
 import porori.backend.domain.member.service.MemberService;
 import porori.backend.domain.user.service.UserService;
 
@@ -84,7 +83,7 @@ public class ApplicationService {
 
     private Club verifyClubManager(Long clubId, Long userId) {
         if (!clubRepository.existsByClubIdAndUserId(clubId, userId))
-            throw new ClubException(NOT_MANAGE_CLUB);
+            throw new ClubException(NOT_CLUB_MANAGER);
         return clubRepository.findById(clubId).orElseThrow(() -> new ClubException(INVALID_CLUB));
     }
 

--- a/src/main/java/porori/backend/domain/application/service/ApplicationService.java
+++ b/src/main/java/porori/backend/domain/application/service/ApplicationService.java
@@ -62,8 +62,8 @@ public class ApplicationService {
         Long managerId = userService.getUserId(token);
         Club club = verifyClubManager(clubId, managerId);
 
-        Application application = changeApplicationStatus(club, userId, COMPLETED);
         memberService.addMember(club, userId, Role.MEMBER);
+        Application application = changeApplicationStatus(club, userId, COMPLETED);
         return ApplicationResponseDTO.from(application);
     }
 

--- a/src/main/java/porori/backend/domain/club/api/ClubController.java
+++ b/src/main/java/porori/backend/domain/club/api/ClubController.java
@@ -46,9 +46,9 @@ public class ClubController {
         return new SuccessResponse<>(SUCCESS, clubService.getSubjectClubs(subjectTitle));
     }
 
-    @GetMapping("/detail")
+    @GetMapping("/detail/{clubId}")
     @Operation(summary = "동호회 정보 조회", description = "동호회 ID로 동호회를 조회한다.")
-    public SuccessResponse<ClubGetResponseDTO> getClub(@RequestParam Long clubId) {
+    public SuccessResponse<ClubGetResponseDTO> getClub(@PathVariable Long clubId) {
         return new SuccessResponse<>(SUCCESS, clubService.getClub(clubId));
     }
 
@@ -59,10 +59,10 @@ public class ClubController {
         return new SuccessResponse<>(SUCCESS, clubService.updateClub(token, clubUpdateRequestDTO));
     }
 
-    @DeleteMapping("/delete")
+    @DeleteMapping("/delete/{clubId}")
     @Operation(summary = "동호회 삭제", description = "자신이 관리자인 동호회를 삭제한다.")
     public SuccessResponse<ClubDeleteResponseDTO> deleteClub(@RequestHeader("Authorization") String token,
-                                                             @RequestParam Long clubId) {
+                                                             @PathVariable Long clubId) {
         return new SuccessResponse<>(SUCCESS, clubService.deleteClub(token, clubId));
     }
 

--- a/src/main/java/porori/backend/domain/club/model/entity/Club.java
+++ b/src/main/java/porori/backend/domain/club/model/entity/Club.java
@@ -66,6 +66,10 @@ public class Club extends BaseEntity {
         this.currentMemberNumber = this.currentMemberNumber + 1;
     }
 
+    public void decreaseCurrentMemberNumber() {
+        this.currentMemberNumber = this.currentMemberNumber - 1;
+    }
+
     public void changeStatus(BaseStatus status) {
         this.status = status;
     }

--- a/src/main/java/porori/backend/domain/club/service/ClubService.java
+++ b/src/main/java/porori/backend/domain/club/service/ClubService.java
@@ -141,6 +141,6 @@ public class ClubService {
 
     private void verifyClubManager(Long clubId, Long userId) {
         if (!clubRepository.existsByClubIdAndUserId(clubId, userId))
-            throw new ClubException(NOT_MANAGE_CLUB);
+            throw new ClubException(NOT_CLUB_MANAGER);
     }
 }

--- a/src/main/java/porori/backend/domain/member/api/MemberController.java
+++ b/src/main/java/porori/backend/domain/member/api/MemberController.java
@@ -36,4 +36,11 @@ public class MemberController {
         return new SuccessResponse<>(SUCCESS, memberService.kickOutMember(token, clubId, userId));
     }
 
+    @PostMapping("/quit/{clubId}")
+    @Operation(summary = "동호회 회원 탈퇴", description = "회원이 동호회를 탈퇴한다.")
+    public SuccessResponse<MemberStatusResponseDTO> quitMember(@RequestHeader("Authorization") String token,
+                                                               @PathVariable Long clubId) {
+        return new SuccessResponse<>(SUCCESS, memberService.quitMember(token, clubId));
+    }
+
 }

--- a/src/main/java/porori/backend/domain/member/service/MemberService.java
+++ b/src/main/java/porori/backend/domain/member/service/MemberService.java
@@ -72,6 +72,9 @@ public class MemberService {
 
         member.changeStatus(BaseStatus.INACTIVE);
         memberRepository.save(member);
+
+        club.decreaseCurrentMemberNumber();
+        clubRepository.save(club);
         return MemberStatusResponseDTO.from(member);
     }
 }

--- a/src/main/java/porori/backend/domain/member/service/MemberService.java
+++ b/src/main/java/porori/backend/domain/member/service/MemberService.java
@@ -60,7 +60,7 @@ public class MemberService {
 
     private Club verifyClubManager(Long clubId, Long userId) {
         if (!clubRepository.existsByClubIdAndUserId(clubId, userId))
-            throw new ClubException(NOT_MANAGE_CLUB);
+            throw new ClubException(NOT_CLUB_MANAGER);
         return clubRepository.findById(clubId).orElseThrow(() -> new ClubException(INVALID_CLUB));
     }
 

--- a/src/main/java/porori/backend/global/common/status/ErrorStatus.java
+++ b/src/main/java/porori/backend/global/common/status/ErrorStatus.java
@@ -25,7 +25,8 @@ public enum ErrorStatus {
 
     INVALID_JWT(401, "유효하지 않은 JWT입니다."),
 
-    NOT_MANAGE_CLUB(403, "현재 접속한 유저가 관리하는 동호회가 아닙니다."),
+    NOT_CLUB_MANAGER(403, "현재 접속한 유저가 관리하는 동호회가 아닙니다."),
+    MANAGER_CANT_QUIT(403, "동호회 관리자는 동호회를 탈퇴할 수 없습니다."),
 
     NOT_EXIST_APPLICATION(404, "신청 내역이 존재하지 않습니다."),
     NOT_EXIST_MEMBER(404, "동호회 회원이 아닙니다."),


### PR DESCRIPTION
## 🔥 Summary
- 동호회 탈퇴 API

## ✏️ Describe your changes
회원 탈퇴 시 soft delete 사용 (강제 탈퇴와 동일)
https://github.com/Hey-Porori/Server_Club/blob/66f4f88eb4fe2585eb8a2ca3ba8c648a736a494a/src/main/java/porori/backend/domain/member/service/MemberService.java#L89

Manager는 동호회 탈퇴 불가하도록 구현
https://github.com/Hey-Porori/Server_Club/blob/66f4f88eb4fe2585eb8a2ca3ba8c648a736a494a/src/main/java/porori/backend/domain/member/service/MemberService.java#L97-L100

## 📖 Review Point
`@RequestParam` 대신 `@PathVariable` 로 변경
https://github.com/Hey-Porori/Server_Club/blob/66f4f88eb4fe2585eb8a2ca3ba8c648a736a494a/src/main/java/porori/backend/domain/club/api/ClubController.java#L49