### PR TITLE
글 삭제 API

### DIFF
--- a/src/main/java/porori/backend/domain/post/api/PostController.java
+++ b/src/main/java/porori/backend/domain/post/api/PostController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import porori.backend.domain.post.model.dto.PostCreateRequestDTO;
+import porori.backend.domain.post.model.dto.PostDeleteResponseDTO;
 import porori.backend.domain.post.model.dto.PostResponseDTO;
 import porori.backend.domain.post.model.dto.PostSubjectResponseDTO;
 import porori.backend.domain.post.service.PostService;
@@ -57,5 +58,12 @@ public class PostController {
                                                     @PathVariable Long clubId,
                                                     @PathVariable Long postId) {
         return new SuccessResponse<>(SUCCESS, postService.getPost(token, clubId, postId));
+    }
+
+    @DeleteMapping("/delete/{postId}")
+    @Operation(summary = "글 삭제", description = "자신이 작성한 글을 삭제한다.")
+    public SuccessResponse<PostDeleteResponseDTO> deletePost(@RequestHeader("Authorization") String token,
+                                                             @PathVariable Long postId) {
+        return new SuccessResponse<>(SUCCESS, postService.deletePost(token, postId));
     }
 }

--- a/src/main/java/porori/backend/domain/post/model/dto/PostDeleteResponseDTO.java
+++ b/src/main/java/porori/backend/domain/post/model/dto/PostDeleteResponseDTO.java
@@ -1,0 +1,22 @@
+package porori.backend.domain.post.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import porori.backend.domain.post.model.entity.Post;
+
+@Schema(description = "글 삭제 Response : 글 삭제 후 얻을 수 있는 정보")
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class PostDeleteResponseDTO {
+
+    @Schema(description = "글 ID", example = "1")
+    private Long postId;
+
+    public static PostDeleteResponseDTO from(Post post) {
+        return PostDeleteResponseDTO.builder()
+                .postId(post.getPostId())
+                .build();
+    }
+}

--- a/src/main/java/porori/backend/domain/post/model/dto/PostResponseDTO.java
+++ b/src/main/java/porori/backend/domain/post/model/dto/PostResponseDTO.java
@@ -21,6 +21,9 @@ public class PostResponseDTO {
     @Schema(description = "유저 프로필 사진 url", example = "picture.png")
     private String imageUrl;
 
+    @Schema(description = "해당 글 작성 여부", example = "true")
+    private boolean isWriter;
+
     @Schema(description = "글 제목", example = "등산 가실 분")
     private String title;
 
@@ -33,11 +36,12 @@ public class PostResponseDTO {
     @Schema(description = "글 주제", example = "같이가요")
     private String subject;
 
-    public static PostResponseDTO of(Post post, MemberResponseDTO memberResponseDTO) {
+    public static PostResponseDTO of(Post post, MemberResponseDTO memberResponseDTO, boolean isWriter) {
         return PostResponseDTO.builder()
                 .postId(post.getPostId())
                 .nickName(memberResponseDTO.getNickName())
                 .imageUrl(memberResponseDTO.getImageUrl())
+                .isWriter(isWriter)
                 .title(post.getTitle())
                 .content(post.getContent())
                 .isImportant(post.isImportant())

--- a/src/main/java/porori/backend/domain/post/model/entity/Post.java
+++ b/src/main/java/porori/backend/domain/post/model/entity/Post.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.global.common.entity.BaseEntity;
+import porori.backend.global.common.status.BaseStatus;
 
 import javax.persistence.*;
 
@@ -47,6 +48,10 @@ public class Post extends BaseEntity {
         this.content = content;
         this.isImportant = isImportant;
         this.subject = subject;
+    }
+
+    public void changeStatus(BaseStatus status) {
+        this.status = status;
     }
 
 }

--- a/src/main/java/porori/backend/domain/post/repository/PostRepository.java
+++ b/src/main/java/porori/backend/domain/post/repository/PostRepository.java
@@ -17,4 +17,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByClubAndSubjectAndStatus(Club club, Subject subject,BaseStatus status);
 
     boolean existsByPostIdAndClub(Long postId, Club club);
+
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/porori/backend/domain/post/service/PostService.java
+++ b/src/main/java/porori/backend/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import porori.backend.domain.member.model.dto.MemberResponseDTO;
 import porori.backend.domain.member.repository.MemberRepository;
 import porori.backend.domain.post.exception.PostException;
 import porori.backend.domain.post.model.dto.PostCreateRequestDTO;
+import porori.backend.domain.post.model.dto.PostDeleteResponseDTO;
 import porori.backend.domain.post.model.dto.PostResponseDTO;
 import porori.backend.domain.post.model.dto.PostSubjectResponseDTO;
 import porori.backend.domain.post.model.entity.Post;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 import static porori.backend.domain.post.model.entity.Subject.EMPTY;
 import static porori.backend.domain.post.model.entity.Subject.valueOfSubject;
 import static porori.backend.global.common.status.BaseStatus.ACTIVE;
+import static porori.backend.global.common.status.BaseStatus.INACTIVE;
 import static porori.backend.global.common.status.ErrorStatus.*;
 
 @Service
@@ -116,5 +118,20 @@ public class PostService {
     private void verifyClubPost(Long postId, Club club) {
         if (!postRepository.existsByPostIdAndClub(postId, club))
             throw new PostException(NOT_CLUB_POST);
+    }
+
+    public PostDeleteResponseDTO deletePost(String token, Long postId) {
+        Long userId = userService.getUserId(token);
+        Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(INVALID_POST));
+        verifyUserPost(postId, userId);
+
+        post.changeStatus(INACTIVE);
+        postRepository.save(post);
+        return PostDeleteResponseDTO.from(post);
+    }
+
+    private void verifyUserPost(Long postId, Long userId) {
+        if (!postRepository.existsByPostIdAndUserId(postId, userId))
+            throw new PostException(NOT_USER_POST);
     }
 }

--- a/src/main/java/porori/backend/domain/post/service/PostService.java
+++ b/src/main/java/porori/backend/domain/post/service/PostService.java
@@ -52,7 +52,7 @@ public class PostService {
 
         postRepository.save(post);
         MemberResponseDTO memberResponseDTO = userService.getMemberResponseDTO(List.of(userId)).get(0);
-        return PostResponseDTO.of(post, memberResponseDTO);
+        return PostResponseDTO.of(post, memberResponseDTO, true);
     }
 
     private void verifyClubMember(Club club, Long userId) {
@@ -76,8 +76,10 @@ public class PostService {
 
         return posts.stream()
                 .map(post -> {
-                    MemberResponseDTO memberResponseDTO = userService.getMemberResponseDTO(List.of(post.getUserId())).get(0);
-                    return PostResponseDTO.of(post, memberResponseDTO);
+                    Long writerId = post.getUserId();
+                    MemberResponseDTO memberResponseDTO = userService.getMemberResponseDTO(List.of(writerId)).get(0);
+                    boolean isWriter = writerId.equals(userId);
+                    return PostResponseDTO.of(post, memberResponseDTO, isWriter);
                 })
                 .collect(Collectors.toList());
     }
@@ -92,8 +94,10 @@ public class PostService {
 
         return posts.stream()
                 .map(post -> {
-                    MemberResponseDTO memberResponseDTO = userService.getMemberResponseDTO(List.of(post.getUserId())).get(0);
-                    return PostResponseDTO.of(post, memberResponseDTO);
+                    Long writerId = post.getUserId();
+                    MemberResponseDTO memberResponseDTO = userService.getMemberResponseDTO(List.of(writerId)).get(0);
+                    boolean isWriter = writerId.equals(userId);
+                    return PostResponseDTO.of(post, memberResponseDTO, isWriter);
                 })
                 .collect(Collectors.toList());
     }
@@ -110,9 +114,11 @@ public class PostService {
         verifyClubPost(postId, club);
 
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(INVALID_POST));
-        MemberResponseDTO memberResponseDTO = userService.getMemberResponseDTO(List.of(post.getUserId())).get(0);
+        Long writerId = post.getUserId();
+        MemberResponseDTO memberResponseDTO = userService.getMemberResponseDTO(List.of(writerId)).get(0);
+        boolean isWriter = writerId.equals(userId);
 
-        return PostResponseDTO.of(post, memberResponseDTO);
+        return PostResponseDTO.of(post, memberResponseDTO, isWriter);
     }
 
     private void verifyClubPost(Long postId, Club club) {

--- a/src/main/java/porori/backend/global/common/status/ErrorStatus.java
+++ b/src/main/java/porori/backend/global/common/status/ErrorStatus.java
@@ -28,6 +28,7 @@ public enum ErrorStatus {
     NOT_CLUB_MANAGER(403, "현재 접속한 유저가 관리하는 동호회가 아닙니다."),
     MANAGER_CANT_QUIT(403, "동호회 관리자는 동호회를 탈퇴할 수 없습니다."),
     NOT_CLUB_POST(403, "해당 동호회의 글의 아닙니다."),
+    NOT_USER_POST(403, "현재 접속한 유저가 작성한 글이 아닙니다."),
 
     NOT_EXIST_APPLICATION(404, "신청 내역이 존재하지 않습니다."),
     NOT_EXIST_MEMBER(404, "동호회 회원이 아닙니다."),


### PR DESCRIPTION
## 🔥 Summary
- 글 삭제 API

## ✏️ Describe your changes
본인이 작성한 글인지 검증
https://github.com/Hey-Porori/Server_Club/blob/1d4222ac8b1ddd29bc7a2be7d0f824cc695020c4/src/main/java/porori/backend/domain/post/service/PostService.java#L133-L136

soft delete 사용
https://github.com/Hey-Porori/Server_Club/blob/1d4222ac8b1ddd29bc7a2be7d0f824cc695020c4/src/main/java/porori/backend/domain/post/service/PostService.java#L128

## 📖 Review Point
글 삭제 시 본인이 작성한 글이 아님을 알릴지 (현재 구현한 방법)
https://github.com/Hey-Porori/Server_Club/blob/1d4222ac8b1ddd29bc7a2be7d0f824cc695020c4/src/main/java/porori/backend/global/common/status/ErrorStatus.java#L31
아니면 글 조회 시 본인이 작성한 글의 여부를 함께 반환할지 (삭제 버튼 비활성화를 위해)
고민입니다