### PR TITLE
댓글 삭제 API

### DIFF
--- a/src/main/java/porori/backend/domain/comment/api/CommentController.java
+++ b/src/main/java/porori/backend/domain/comment/api/CommentController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import porori.backend.domain.comment.model.dto.CommentCreateRequestDTO;
+import porori.backend.domain.comment.model.dto.CommentDeleteResponseDTO;
 import porori.backend.domain.comment.model.dto.CommentResponseDTO;
 import porori.backend.domain.comment.service.CommentService;
 import porori.backend.global.common.dto.response.SuccessResponse;
@@ -35,5 +36,12 @@ public class CommentController {
     public SuccessResponse<List<CommentResponseDTO>> getAllComments(@Parameter(hidden = true) @RequestHeader("Authorization") String token,
                                                                     @PathVariable Long postId) {
         return new SuccessResponse<>(SUCCESS, commentService.getAllComments(token, postId));
+    }
+
+    @DeleteMapping("/delete/{commentId}")
+    @Operation(summary = "댓글 삭제", description = "자신이 작성한 댓글을 삭제한다.")
+    public SuccessResponse<CommentDeleteResponseDTO> deleteComment(@Parameter(hidden = true) @RequestHeader("Authorization") String token,
+                                                                   @PathVariable Long commentId) {
+        return new SuccessResponse<>(SUCCESS, commentService.deleteComment(token, commentId));
     }
 }

--- a/src/main/java/porori/backend/domain/comment/model/dto/CommentDeleteResponseDTO.java
+++ b/src/main/java/porori/backend/domain/comment/model/dto/CommentDeleteResponseDTO.java
@@ -1,0 +1,22 @@
+package porori.backend.domain.comment.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import porori.backend.domain.comment.model.entity.Comment;
+
+@Schema(description = "댓글 삭제 Response : 댓글 삭제 후 얻을 수 있는 정보")
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class CommentDeleteResponseDTO {
+
+    @Schema(description = "댓글 ID", example = "1")
+    private Long commentId;
+
+    public static CommentDeleteResponseDTO from(Comment comment) {
+        return CommentDeleteResponseDTO.builder()
+                .commentId(comment.getCommentId())
+                .build();
+    }
+}

--- a/src/main/java/porori/backend/domain/comment/model/entity/Comment.java
+++ b/src/main/java/porori/backend/domain/comment/model/entity/Comment.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import porori.backend.domain.post.model.entity.Post;
 import porori.backend.global.common.entity.BaseEntity;
+import porori.backend.global.common.status.BaseStatus;
 
 import javax.persistence.*;
 
@@ -34,5 +35,9 @@ public class Comment extends BaseEntity {
         this.userId = userId;
         this.post = post;
         this.content = content;
+    }
+
+    public void changeStatus(BaseStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/porori/backend/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/porori/backend/domain/comment/repository/CommentRepository.java
@@ -12,4 +12,6 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByPostAndStatus(Post post, BaseStatus status);
+
+    boolean existsByCommentIdAndUserId(Long commentId, Long userId);
 }

--- a/src/main/java/porori/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/porori/backend/domain/comment/service/CommentService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import porori.backend.domain.club.model.entity.Club;
 import porori.backend.domain.comment.exception.CommentException;
 import porori.backend.domain.comment.model.dto.CommentCreateRequestDTO;
+import porori.backend.domain.comment.model.dto.CommentDeleteResponseDTO;
 import porori.backend.domain.comment.model.dto.CommentResponseDTO;
 import porori.backend.domain.comment.model.entity.Comment;
 import porori.backend.domain.comment.repository.CommentRepository;
@@ -18,8 +19,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static porori.backend.global.common.status.BaseStatus.ACTIVE;
-import static porori.backend.global.common.status.ErrorStatus.INVALID_POST;
-import static porori.backend.global.common.status.ErrorStatus.NOT_EXIST_MEMBER;
+import static porori.backend.global.common.status.BaseStatus.INACTIVE;
+import static porori.backend.global.common.status.ErrorStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -69,5 +70,20 @@ public class CommentService {
                     boolean isWriter = writerId.equals(userId);
                     return CommentResponseDTO.of(comment, memberResponseDTO, isWriter);
                 }).collect(Collectors.toList());
+    }
+
+    public CommentDeleteResponseDTO deleteComment(String token, Long commentId) {
+        Long userId = userService.getUserId(token);
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new CommentException(INVALID_COMMENT));
+        verifyUserComment(commentId, userId);
+
+        comment.changeStatus(INACTIVE);
+        commentRepository.save(comment);
+        return CommentDeleteResponseDTO.from(comment);
+    }
+
+    private void verifyUserComment(Long commentId, Long userId) {
+        if (!commentRepository.existsByCommentIdAndUserId(commentId, userId))
+            throw new CommentException(NOT_USER_COMMENT);
     }
 }

--- a/src/main/java/porori/backend/global/common/status/ErrorStatus.java
+++ b/src/main/java/porori/backend/global/common/status/ErrorStatus.java
@@ -18,6 +18,7 @@ public enum ErrorStatus {
 
     INVALID_CLUB(400, "유효하지 않은 동호회 ID입니다."),
     INVALID_POST(400, "유효하지 않은 글 ID입니다."),
+    INVALID_COMMENT(400, "유효하지 않은 댓글 ID입니다."),
     INVALID_SUBJECT_TITLE(400, "유효하지 않은 동호회 주제입니다."),
     INVALID_POST_SUBJECT(400, "유효하지 않은 글 주제입니다."),
     EXIST_APPLICATION(400, "이미 가입 신청한 동호회입니다."),
@@ -29,6 +30,7 @@ public enum ErrorStatus {
     MANAGER_CANT_QUIT(403, "동호회 관리자는 동호회를 탈퇴할 수 없습니다."),
     NOT_CLUB_POST(403, "해당 동호회의 글의 아닙니다."),
     NOT_USER_POST(403, "현재 접속한 유저가 작성한 글이 아닙니다."),
+    NOT_USER_COMMENT(403, "현재 접속한 유저가 작성한 댓글이 아닙니다."),
 
     NOT_EXIST_APPLICATION(404, "신청 내역이 존재하지 않습니다."),
     NOT_EXIST_MEMBER(404, "동호회 회원이 아닙니다."),


### PR DESCRIPTION
## 🔥 Summary
- 댓글 삭제 API
  - 자신이 작성한 댓글을 삭제하는 API

## ✏️ Describe your changes
본인이 작성한 댓글인지 검증
https://github.com/Hey-Porori/Server_Club/blob/aa93e6f0283b4b82ec65843a1a913ea6d8d44a86/src/main/java/porori/backend/domain/comment/service/CommentService.java#L85-L88

soft delete 사용
https://github.com/Hey-Porori/Server_Club/blob/aa93e6f0283b4b82ec65843a1a913ea6d8d44a86/src/main/java/porori/backend/domain/comment/service/CommentService.java#L80

## 📖 Review Point
본인이 작성한 댓글인지 여부를 함께 반환
https://github.com/Hey-Porori/Server_Club/blob/aa93e6f0283b4b82ec65843a1a913ea6d8d44a86/src/main/java/porori/backend/domain/comment/model/dto/CommentResponseDTO.java#L24-L25

해당 값이 true이면 삭제 버튼 활성화